### PR TITLE
feat(builder): add possibility to chain once calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ describe("aws-mock", () => {
   it("Should succeed", async () => {
     const m = on(SecretsManager)
       .mock("getSecretValue")
-      // Result type will be inferred by typescript
       .resolve({ SecretString: "foo-bar" });
 
     const res = foo();
@@ -54,14 +53,40 @@ describe("aws-mock", () => {
   });
 
   it("Should fail", async () => {
-    const m = on(SecretsManager)
-      .mock("getSecretValue")
-      .reject("foo-baz");
+    const m = on(SecretsManager).mock("getSecretValue").reject("foo-baz");
 
     const res = foo();
 
     await expect(res).rejects.toMatchSnapshot("Result");
     expect(m.mock).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+chain mocks
+
+```typescript
+import { SecretsManager } from "aws-sdk";
+import { on } from "@jurijzahn8019/aws-promise-jest-mock";
+import { foo } from "./code.ts";
+
+jest.mock("aws-sdk");
+
+describe("aws-mock", () => {
+  it("Should succeed", async () => {
+    const m = on(SecretsManager)
+      .mock("getSecretValue")
+      .resolveOnce({ SecretString: "foo-bar" })
+      .resolveOnce({ SecretString: "baz-bar" })
+      .rejectOnce({ SecretString: "baz-bar" });
+
+    const res = foo();
+
+    await expect(res).resolves.toMatchSnapshot("Result 1");
+    await expect(res).resolves.toMatchSnapshot("Result 2");
+    await expect(res).rejects.toMatchSnapshot("Error");
+
+    expect(m.mock).toHaveBeenCalledTimes(3);
   });
 });
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jurijzahn8019/aws-promise-jest-mock",
-  "version": "2.1.5",
+  "version": "2.2.0-feat-chain-once-calls.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jurijzahn8019/aws-promise-jest-mock",
-  "version": "2.1.5",
+  "version": "2.2.0-feat-chain-once-calls.0",
   "private": false,
   "description": "simple libraray for jest-tested projects to create jest mock for js aws-sdk  .promise() calls",
   "main": "dist/index.cjs.js",

--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`aws-mock Should chain calls: Rejection Mock 1`] = `[Error: Third Call]`;
+
+exports[`aws-mock Should chain calls: getSecretValue 1 1`] = `
+Object {
+  "SecretString": "FOO",
+}
+`;
+
+exports[`aws-mock Should chain calls: getSecretValue 2 1`] = `
+Object {
+  "SecretString": "FOO_SECRET",
+}
+`;
+
 exports[`aws-mock Should chain mocks: createSecret 1`] = `
 Object {
   "Name": "FOO_SECRET",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -11,7 +11,7 @@ describe("aws-mock", () => {
       .resolve({ SecretString: "foo-bar" });
 
     const res = new SecretsManager({
-      credentials: { accessKeyId: "rootkeyfoo" } as any
+      credentials: { accessKeyId: "rootkeyfoo" } as any,
     })
       .getSecretValue({ SecretId: "bar-baz" })
       .promise();
@@ -22,9 +22,7 @@ describe("aws-mock", () => {
   });
 
   it("Should create reject mock from type", async () => {
-    const m = on(SecretsManager)
-      .mock("getSecretValue")
-      .reject("foo-baz");
+    const m = on(SecretsManager).mock("getSecretValue").reject("foo-baz");
 
     const res = new SecretsManager()
       .getSecretValue({ SecretId: "bar-baz" })
@@ -75,7 +73,7 @@ describe("aws-mock", () => {
       .resolve(
         () => {
           return {
-            SecretString: "FOO"
+            SecretString: "FOO",
           };
         },
         { snapshot: false }
@@ -94,7 +92,7 @@ describe("aws-mock", () => {
       .mock("getSecretValue")
       .resolve(() => {
         return {
-          SecretString: "FOO"
+          SecretString: "FOO",
         };
       })
       .and.mock("createSecret")
@@ -113,10 +111,41 @@ describe("aws-mock", () => {
     expect(m.serviceMock).toHaveBeenCalledTimes(1);
   });
 
+  it("Should chain calls", async () => {
+    const m = on(SecretsManager, { snapshot: false })
+      .mock("getSecretValue")
+      .resolveOnce(() => {
+        return {
+          SecretString: "FOO",
+        };
+      })
+      .resolveOnce({ SecretString: "FOO_SECRET" })
+      .rejectOnce("Third Call");
+
+    const smm = new SecretsManager();
+
+    await expect(
+      smm.getSecretValue({ SecretId: "bar-baz" }).promise()
+    ).resolves.toMatchSnapshot("getSecretValue 1");
+
+    await expect(
+      smm.getSecretValue({ SecretId: "FOO" }).promise()
+    ).resolves.toMatchSnapshot("getSecretValue 2");
+
+    await expect(
+      smm.getSecretValue({ SecretId: "NONE" }).promise()
+    ).rejects.toMatchSnapshot("Rejection Mock");
+
+    expect(
+      smm.getSecretValue({ SecretId: "this will return nothing" })
+    ).toBeUndefined();
+
+    expect(m.serviceMock).toHaveBeenCalledTimes(1);
+    expect(m.mock).toHaveBeenCalledTimes(4);
+  });
+
   it("Should work with DocumentClient", async () => {
-    const m = on(DynamoDB.DocumentClient)
-      .mock("scan")
-      .resolve({ Items: [] });
+    const m = on(DynamoDB.DocumentClient).mock("scan").resolve({ Items: [] });
 
     await expect(
       new DynamoDB.DocumentClient().scan({ TableName: "foo" }).promise()

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,12 @@ export interface MockOptions {
    * @default true
    */
   snapshot?: boolean;
+
+  /**
+   * If set to true, will use mockImplementationOnce instead of mockImplementation
+   * This allows to chain multiple results for a same function
+   */
+  once?: boolean;
 }
 
 /**
@@ -33,7 +39,7 @@ export interface MockOptions {
  * @template S Type of the AWS Service to mock
  */
 export interface ServiceConstructor<S extends object = Service> {
-  new (options?: any): S; // TODO: TS 3.7 ConstructorParameters<ServiceConstructor<S>>): S;
+  new (options?: any): S; // TODO: ConstructorParameters<ServiceConstructor<S>>): S;
 }
 
 /**


### PR DESCRIPTION
fixes: Is it possible to chain multiple resolvers on the same query #430