### PR TITLE
feat(mock): improve request object and its type annotation

### DIFF
--- a/src/AwsFunctionMockBuilder.ts
+++ b/src/AwsFunctionMockBuilder.ts
@@ -118,8 +118,8 @@ export class AwsFunctionMockBuilder<
   } & MockOptions): FunctionMockImpl<S, C, F, E> {
     const { snapshot = true } = { ...this.options, ...options };
     const httpRequest = new HttpRequest(
-      this.service.endpoint || "",
-      this.service.config?.region || ""
+      (this.service as Service).endpoint || "",
+      (this.service as Service).config?.region || ""
     );
     httpRequest.headers = {};
     const request: jest.Mocked<Request<any, E>> = {

--- a/src/AwsFunctionMockBuilder.ts
+++ b/src/AwsFunctionMockBuilder.ts
@@ -107,7 +107,7 @@ export class AwsFunctionMockBuilder<
    *   }
    * @returns service function mock implementation
    */
-  private getMockImpl({
+  protected getMockImpl({
     result,
     error,
     options = {},

--- a/src/AwsFunctionMockBuilder.ts
+++ b/src/AwsFunctionMockBuilder.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Service, HttpRequest, Request } from "aws-sdk";
 
@@ -93,7 +94,7 @@ export class AwsFunctionMockBuilder<
    * @param value a function candidate
    * @returns a boolean value indication whether value is a function
    */
-  private static isFunc(value: any): value is Function {
+  private static isFunc(value: any): value is (...args: any[]) => any {
     return typeof value === "function";
   }
 

--- a/src/AwsServiceMockBuilder.ts
+++ b/src/AwsServiceMockBuilder.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Service, AWSError } from "aws-sdk";
 import {
@@ -5,7 +6,7 @@ import {
   MockOptions,
   ServiceMock,
   FunctionMock,
-  ServiceFunction
+  ServiceFunction,
 } from "./types";
 import { AwsFunctionMockBuilder } from "./AwsFunctionMockBuilder";
 

--- a/src/__fixtures__/infer.ts
+++ b/src/__fixtures__/infer.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function sut(a: string, b: number) {
+export function sut(a: string, b: number): { a: string; b: number } {
   return { a, b };
 }

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -10,7 +10,7 @@ describe("utils", () => {
       mock.mockImplementation((a, b) => {
         return {
           a: `a: ${a}`,
-          b: 100 + b
+          b: 100 + b,
         };
       });
       expect(mock).toBe(sut);


### PR DESCRIPTION
We need a better mock for the AWS Request object, in case you will be adding a listener by using the method `on` or the `httpRequest` property.